### PR TITLE
[IT-2051] Grant ec2:DescribeRegions to the lambda

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -56,8 +56,7 @@ Resources:
             Effect: Allow
             Resource: "*"
             Action:
-              - ec2:DescribeInstance*
-              - ec2:DescribeVolume*
+              - ec2:Describe*
               - ec2:DeleteVolume
 
   FunctionRole:   # execute lambda function with this role


### PR DESCRIPTION
The lambda is failing to describe regions due to a permissions issue. The lambda lacks ec2:DescribeRegions, add it by opening up the permission to all of ec2:Describe* since they are all read-only actions.
