### PR TITLE
[IT-2051] Bugfix: Tags may not be set

### DIFF
--- a/ebs_cleanup/app.py
+++ b/ebs_cleanup/app.py
@@ -58,10 +58,11 @@ def local_volume_filter(volumes, age_string):
             continue
 
         # Ignore any volumes marked with the appropirate tag ('lambda-ebs-cleanup:ignore' == 'True')
-        LOG.info(f"Tags: {v['Tags']}")
+        tags = v.get('Tags', [])
+        LOG.info(f"Tags: {tags}")
         skip_tag = False
-        if v['Tags']:  # skip the case where tags is None (not iterable)
-            for tag in v['Tags']:
+        if tags:  # skip the case where tags is None (not iterable)
+            for tag in tags:
                 if 'Key' in tag and tag['Key'] == IGNORE_TAG:
                     if 'Value' in tag and tag['Value'] in ['True', 'true']:
                         LOG.info(f"Skipping {v['VolumeId']} due to {IGNORE_TAG} tag")

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -15,7 +15,8 @@ def volume_factory(volume_id, create_time, attachments, tags):
     result['VolumeId'] = str(volume_id)  # coerce ints to strings
     result['CreateTime'] = create_time
     result['Attachments'] = attachments
-    result['Tags'] = tags
+    if tags is not None:
+        result['Tags'] = tags
     return result
 
 def test_local_filter():
@@ -29,7 +30,7 @@ def test_local_filter():
     now = datetime.datetime.now()
     yesterday = now - datetime.timedelta(days=1)
 
-    mv1 = volume_factory(1, yesterday, [], [])
+    mv1 = volume_factory(1, yesterday, [], None)
     mv2 = volume_factory(2, yesterday, ["mystery-volume",], [])
     mv3 = volume_factory(3, now, [], [])
     mv4 = volume_factory(4, yesterday, [], [{'Key': 'lambda-ebs-cleanup:ignore', 'Value': 'True'}])
@@ -70,7 +71,7 @@ def test_scan():
     yesterday = now - datetime.timedelta(days=1)
 
     mv1 = volume_factory(1, yesterday, [], [])
-    mv2 = volume_factory(2, yesterday, [], [])
+    mv2 = volume_factory(2, yesterday, [], None)
     mv3 = volume_factory(3, yesterday, [], [])
     mv4 = volume_factory(4, now, [], [])
 


### PR DESCRIPTION
The volume may not have any tags set, in which case there will be no `Tags` key. 
Use `.get()` to set avoid a KeyError.
